### PR TITLE
feature: 어드민에서 데이터 저장 시 중복저장 방지 + 로딩바 노출

### DIFF
--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { useEffect, useRef, useState } from 'react';
-import { Navigate, useLocation, useNavigate } from 'react-router';
+import { useRef, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router';
 import { toast, Toaster } from 'sonner';
 
 import { Accordion } from '@/components/account/Accordion';
@@ -18,8 +18,6 @@ import { uploadImageToStorage } from '@/utils/storage';
 
 const AdminPage = () => {
   const navigate = useNavigate();
-  const location = useLocation(); // 현재 경로
-  const prevPathRef = useRef(location.pathname); // 이전경로
   const setDeep = useWeddingStore((state) => state.setDeep);
   const setField = useWeddingStore((state) => state.setField);
 
@@ -27,22 +25,6 @@ const AdminPage = () => {
 
   const [loading, setLoadingOpen] = useState(false);
   const isSavingRef = useRef(false); // 더블클릭 방지(true : 저장중 , false : 저장가능)
-
-  useEffect(() => {
-    // 로딩이 아니라면 경로만 최신화하고 종료
-    if (!loading) {
-      prevPathRef.current = location.pathname;
-      return;
-    }
-
-    // 로딩 중일 때 경로가 실제로 바뀌었다면 로딩 닫기
-    if (prevPathRef.current !== location.pathname) {
-      setLoadingOpen(false);
-    }
-
-    // 항상 마지막에 최신 경로로 갱신
-    prevPathRef.current = location.pathname;
-  }, [location.pathname, loading]);
 
   const shouldFetch = !!uid;
   const { isLoading: infoLoading, notFound } = useWeddingInfo(
@@ -142,7 +124,11 @@ const AdminPage = () => {
           ))}
         </Accordion>
       )}
-      <button css={buttonStyle} onClick={handleSave}>
+      <button
+        css={buttonStyle}
+        disabled={isSavingRef.current}
+        onClick={handleSave}
+      >
         저장하기
       </button>
       <Toaster duration={2000} position="top-center" />


### PR DESCRIPTION
## 📌 이슈 번호

#173 

## 👩‍💻 작업 내용

1. admin.tsx에 로딩관련 컴포넌트 추가
> 데이터 저장 버튼 클릭 시 로딩바 노출
2. 데이터저장 완료 후 화면이동 시 로딩바 제거 : location.pathname 활용
3. 데이터저장 중에 저장버튼 중복 클릭 되지않게 방어로직 추가