### PR TITLE
fix: 풀팝업 헤더 잘림 현상 Android, IOS 대응 css 추가

### DIFF
--- a/src/components/shared/ButtonContentModal.tsx
+++ b/src/components/shared/ButtonContentModal.tsx
@@ -80,8 +80,10 @@ const modalContentStyle = css`
   z-index: 1000;
 
   /* IOS safari safe area 대응 */
-  padding-top: env(safe-area-inset-top);
-  padding-bottom: env(safe-area-inset-bottom);
+  @supports (padding-top: env(safe-area-inset-top)) {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
 
   @supports (padding-top: constant(safe-area-inset-top)) {
     padding-top: constant(safe-area-inset-top);


### PR DESCRIPTION
## 📌 이슈 번호

#186 

## 👩‍💻 작업 내용

OS 별 모바일 상단 Safe Area 대응 개발
- Android :  height: 100dvh;
- IOS : env CSS 환경 변수 활용, constant 구버전 대응
padding-top: env(safe-area-inset-top);
  padding-bottom: env(safe-area-inset-bottom);

  @supports (padding-top: constant(safe-area-inset-top)) {
    padding-top: constant(safe-area-inset-top);
    padding-bottom: constant(safe-area-inset-bottom);
  }

## ❓ 참고 사항

https://www.notion.so/10-5-2a4b1f620ca180e5acf1c43012e07808?source=copy_link