### PR TITLE
feat: 테마 변경 시 필드 초기화

### DIFF
--- a/src/components/theme/ThemeAdmin.tsx
+++ b/src/components/theme/ThemeAdmin.tsx
@@ -2,17 +2,30 @@ import BaseImageInputPreview from '@/components//shared/BaseImageInputPreview';
 import BaseRadioButtonScrollGroup from '@/components/shared/BaseRadioButtonScrollGroup';
 import ThemeTextFields from '@/components/theme/ThemeTextFields';
 import { useWeddingStore } from '@/stores/useWeddingStore';
+import type { ThemeType } from '@/types/wedding';
+import { THEME_TEXT_DEFAULT } from '@/utils/constants/wedding';
 import { themeList, themeScrollList } from '@/utils/themeList';
 
 const ThemeAdmin = () => {
-  const setField = useWeddingStore((state) => state.setField);
+  const setDeep = useWeddingStore((state) => state.setDeep);
 
   const { type } = useWeddingStore((state) => state.values.theme);
 
   const localThemeItem = themeList.find((item) => item.type === type);
 
   const handleChangeRadio = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setField('theme', 'type', e.target.value as typeof type);
+    const nextType = e.target.value as ThemeType;
+
+    setDeep((draft) => {
+      draft.theme.type = nextType;
+
+      Object.assign(draft.theme, THEME_TEXT_DEFAULT);
+
+      draft.themeImage = {
+        localImageList: [],
+        savedImageList: [],
+      };
+    });
   };
 
   return (

--- a/src/utils/constants/wedding.ts
+++ b/src/utils/constants/wedding.ts
@@ -1,4 +1,4 @@
-import type { WeddingInfo } from '@/types/wedding';
+import type { Theme, WeddingInfo } from '@/types/wedding';
 
 export const WEDDING_INITIAL_INFO: WeddingInfo = {
   theme: {
@@ -118,4 +118,15 @@ export const WEDDING_INITIAL_INFO: WeddingInfo = {
     localImageList: [],
     savedImageList: [],
   },
+};
+
+export const THEME_TEXT_DEFAULT: Pick<
+  Theme,
+  'groomEnglishName' | 'brideEnglishName' | 'text1' | 'text2' | 'text3'
+> = {
+  groomEnglishName: '',
+  brideEnglishName: '',
+  text1: '',
+  text2: '',
+  text3: '',
 };


### PR DESCRIPTION
## 📌 이슈 번호

<!-- 이슈 번호 또는 링크 -->
#252 

## 👩‍💻 작업 내용

<!-- 작업한 내용 상세히 작성 -->
- 테마 변경 라디오 버튼 클릭 시 테마 관련 필드 초기화

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resets theme-related state when changing themes and centralizes default theme text values.
> 
> - In `ThemeAdmin.tsx`, replace `setField` with `setDeep` and, on radio change, update `draft.theme.type`, reset text fields via `THEME_TEXT_DEFAULT`, and clear `themeImage.localImageList/savedImageList`.
> - Add `THEME_TEXT_DEFAULT` in `utils/constants/wedding.ts` and update imports to include `Theme` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d06df8b293f2ffb9a4d3e1c3dd2246576c17cc9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->