### PR TITLE
refactor: 최초 로드 시 신랑측 계좌번호 펼치기 미적용 버그 조치 (Accordion props defaultValu…

### DIFF
--- a/src/components/account/Accordion.tsx
+++ b/src/components/account/Accordion.tsx
@@ -4,15 +4,11 @@ import type { ReactNode } from 'react';
 
 type AccordionProps = {
   children: ReactNode;
-  defaultValue?: string[];
+  value?: string[];
 };
 
-export const Accordion = ({ children, defaultValue }: AccordionProps) => (
-  <RadixAccordion.Root
-    css={rootStyle}
-    defaultValue={defaultValue}
-    type="multiple"
-  >
+export const Accordion = ({ children, value }: AccordionProps) => (
+  <RadixAccordion.Root css={rootStyle} type="multiple" value={value}>
     {children}
   </RadixAccordion.Root>
 );

--- a/src/components/account/AccountList.tsx
+++ b/src/components/account/AccountList.tsx
@@ -62,7 +62,7 @@ const AccountList = () => {
         <p css={subtitleStyle}>{accountListSubTitle}</p>
 
         <Accordion
-          defaultValue={[
+          value={[
             groomSide.isExpand ? 'groomSide' : '',
             brideSide.isExpand ? 'brideSide' : '',
           ].filter(Boolean)}


### PR DESCRIPTION
## 📌 이슈 번호

#298 

## 👩‍💻 작업 내용

Accordion props defaultValue -> value 변경

## ❓ 참고 사항

defaultValue : 컴포넌트 마운트 될 때 최초 1회만 적용 -> constant/wedding.ts -> isExpand : false
- 신랑측 isExpand 초기값 true 저장된 상태더라도 초기값이 false 이므로 닫힌채로 로드됨.
value : 리액트 상태와 아코디언 상태 동기화
